### PR TITLE
support Symbols in path

### DIFF
--- a/set.js
+++ b/set.js
@@ -13,7 +13,7 @@ module.exports = function set(reference, pathParts, value) {
         var key = pathParts[index];
 
         if ((typeof result !== 'object' || result === null) && index < pathLength) {
-            if (!isNaN(key)) {
+            if (!Number.isNaN(key)) {
                 result = previousresult[previousKey] = [];
             }
             else {

--- a/tests/index.js
+++ b/tests/index.js
@@ -22,7 +22,8 @@ var getTestData = [
     [['a', 'b'], {a:{b:1}}, 1],
     ['a.b', {a:{b:1}}, 1],
     [['a', 'b'], {}, undefined],
-    ['a.b', {a:{b:{c:1}}}, {c:1}]
+    ['a.b', {a:{b:{c:1}}}, {c:1}],
+    [['a', Symbol.for('b')], {a:{[Symbol.for('b')]:{c:1}}}, {c:1}],
 ];
 
 var setTestData = [
@@ -32,7 +33,8 @@ var setTestData = [
     [['a', 'b', 'c'], {a:{b:null}}, {a:{b:{c:1}}}, 1],
     [['a', 'b'], {a:{b:null}}, {a:{b:{c:1}}}, {c:1}],
     [['a', 'b', 'c'], {a:{b:1}}, {a:{b:{c:2}}}, 2],
-    [['a', 'b', 'c'], {}, {a:{b:{c:1}}}, 1]
+    [['a', 'b', 'c'], {}, {a:{b:{c:1}}}, 1],
+    [['a', Symbol.for('b')], {}, { a: { [Symbol.for('b')]: 1 }}, 1],
 ];
 
 getTestData.forEach(function(data){


### PR DESCRIPTION
Symbol in path array will cause a TypeError in isNaN.

This PR fixes that by using `Number.isNaN` instead.