### PR TITLE
Security Fix for Prototype Pollution - huntr.dev

### DIFF
--- a/set.js
+++ b/set.js
@@ -4,10 +4,10 @@ module.exports = function set(reference, pathParts, value) {
     }
 
     var index = 0,
-    pathLength = pathParts.length,
-    result = reference,
-    previousresult,
-    previousKey;
+        pathLength = pathParts.length,
+        result = reference,
+        previousresult,
+        previousKey;
 
     for(; index < pathLength; index++){
         var key = pathParts[index];

--- a/set.js
+++ b/set.js
@@ -2,16 +2,16 @@ module.exports = function set(reference, pathParts, value) {
     if(typeof pathParts === 'string'){
         pathParts = pathParts.split('.');
     }
-    
+
     var index = 0,
     pathLength = pathParts.length,
     result = reference,
     previousresult,
     previousKey;
-    
+
     for(; index < pathLength; index++){
         var key = pathParts[index];
-        
+
         if ((typeof result !== 'object' || result === null) && index < pathLength) {
             if (typeof key !== 'symbol' && !Number.isNaN(Number(key))) {
                 result = previousresult[previousKey] = [];

--- a/set.js
+++ b/set.js
@@ -2,16 +2,16 @@ module.exports = function set(reference, pathParts, value) {
     if(typeof pathParts === 'string'){
         pathParts = pathParts.split('.');
     }
-
+    
     var index = 0,
-        pathLength = pathParts.length,
-        result = reference,
-        previousresult,
-        previousKey;
-
+    pathLength = pathParts.length,
+    result = reference,
+    previousresult,
+    previousKey;
+    
     for(; index < pathLength; index++){
         var key = pathParts[index];
-
+        
         if ((typeof result !== 'object' || result === null) && index < pathLength) {
             if (typeof key !== 'symbol' && !Number.isNaN(Number(key))) {
                 result = previousresult[previousKey] = [];
@@ -24,9 +24,14 @@ module.exports = function set(reference, pathParts, value) {
             result[key] = value;
         }
         else {
+            if (isPrototypePolluted(key)) continue;
             previousresult = result;
             previousKey = key;
             result = result[key];
         }
     }
 };
+
+function isPrototypePolluted(key) {
+    return ['__proto__', 'constructor', 'prototype'].includes(key);
+}


### PR DESCRIPTION
https://huntr.dev/users/arjunshibu has fixed the Prototype Pollution vulnerability 🔨. Think you could fix a vulnerability like this?

Get involved at https://huntr.dev/

Q | A
Version Affected | ALL
Bug Fix | YES
Original Pull Request | https://github.com/418sec/unbox/pull/2
Vulnerability README | https://github.com/418sec/huntr/blob/master/bounties/npm/unbox/1/README.md

### User Comments:

### :bar_chart: Metadata *

`unbox` is vulnerable to `Prototype Pollution`.

#### Bounty URL: https://www.huntr.dev/bounties/1-npm-unbox

### :gear: Description *

Prototype Pollution refers to the ability to inject properties into existing JavaScript language construct prototypes, such as objects.
JavaScript allows all Object attributes to be altered, including their magical attributes such as `__proto__`, `constructor` and `prototype`. An attacker manipulates these attributes to overwrite, or pollute, a JavaScript application object prototype of the base object by injecting other values. Properties on the Object.prototype are then inherited by all the JavaScript objects through the prototype chain.

### :computer: Technical Description *

Fix implemented by not allowing to modify object prototype.

### :bug: Proof of Concept (PoC) *

1. Create the following PoC file:
```JavaScript
// poc.js
var unbox = require("./")
var myObject = {}
console.log("Before : " + {}.polluted);
unbox.set(myObject, '__proto__.polluted', 'Yes! Its Polluted');
console.log("After : " + {}.polluted);
```
2. Execute the following commands in terminal:
```bash
npm i unbox # Install affected module
node poc.js #  Run the PoC
```
3. Check the Output:
```
Before : undefined
After : Yes! Its Polluted
```

### :fire: Proof of Fix (PoF) *

![image](https://user-images.githubusercontent.com/43996156/103800164-10021d80-5072-11eb-82de-b6958797c831.png)

### +1 User Acceptance Testing (UAT)

* I've executed unit tests.
* After fix the functionality is unaffected.
